### PR TITLE
Update python@3.7.rb

### DIFF
--- a/Formula/python@3.7.rb
+++ b/Formula/python@3.7.rb
@@ -4,7 +4,7 @@ class PythonAT37 < Formula
   url "https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tar.xz"
   sha256 "f8d82e7572c86ec9d55c8627aae5040124fd2203af400c383c821b980306ee6b"
   license "Python-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://www.python.org/ftp/python/"
@@ -81,8 +81,8 @@ class PythonAT37 < Formula
   # ourselves.
   # https://bugs.python.org/issue42504
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/05a27807/python/3.7.9.patch"
-    sha256 "486188ac1a4af4565de5ad54949939bb69bffc006297e8eac9339f19d7d7492b"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/c4bc563a8d008ebd0e8d927c043f6dd132d3ba89/python/big-sur-3.7.patch"
+    sha256 "67c99bdf0bbe0a640d70747aad514cd74602e7c4715fd15f1f9863eef257735e"
   end
 
   # Link against libmpdec.so.3, update for mpdecimal.h symbol cleanup.


### PR DESCRIPTION
The issue addresses the part where `MACOSX_DEPLOYMENT_TARGET` comes to be out as an integer instead of String(Float). This seems to be an issue with the new MacOS's BigSur update and has been solved in `python3.9` (MACOSX_DEPLOYMENT_TARGET).  However, there's no fix for python3.7 yet.

(https://github.com/python/cpython/pull/24341)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
